### PR TITLE
Externalize Configuration with NPM_BIN_PATH variable.

### DIFF
--- a/mysite/settings.py
+++ b/mysite/settings.py
@@ -172,8 +172,7 @@ INTERNAL_IPS = [
     "*",
 ]
 
-# NPM_BIN_PATH = "C:/Users/User/AppData/Roaming/npm/"
-NPM_BIN_PATH = r"D:\nodejs\npm.cmd"
+NPM_BIN_PATH = config('NPM_BIN_PATH', cast=str, default='/usr/local/bin/npm')
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/

--- a/sample.env
+++ b/sample.env
@@ -12,3 +12,6 @@ ALLOWED_HOSTS = *.ku.th, localhost, 127.0.0.1, ::1
 
 # Your timezone
 TIME_ZONE = Asia/Bangkok
+
+# You need to specify NPM_BIN_PATH on your device by using `where npm` to find your path
+NPM_BIN_PATH = your-npm-bin-path


### PR DESCRIPTION
It should work on other OS because anyone who uses this needs to specify NPM_BIN_PATH on their device.